### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/YnFOR/security/code-scanning/1](https://github.com/teremuhamblin/YnFOR/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` to restrict `GITHUB_TOKEN` to the minimum needed.  
Best fix here: define workflow-level permissions right after the `on` block so it applies to all jobs (including current `build`), with:

- `contents: read`

This preserves existing behavior (`actions/checkout` requires reading repository contents) while preventing unnecessary write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
