### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ynfor-infra.yml
+++ b/.github/workflows/ynfor-infra.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   infra:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/YnFOR/security/code-scanning/5](https://github.com/teremuhamblin/YnFOR/security/code-scanning/5)

Add an explicit `permissions` block in `.github/workflows/ynfor-infra.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the least-privilege needed is `contents: read` (required for checkout and reading repository content). No functional behavior changes are expected.

Best single fix:
- Edit `.github/workflows/ynfor-infra.yml`
- Insert after the `on:` trigger block (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
