### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/YnFOR/security/code-scanning/4](https://github.com/teremuhamblin/YnFOR/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default.  
Best fix here: set workflow-level permissions to the minimum required for current steps.

For `.github/workflows/release.yml`, add under `on:` (before `jobs:`):

- `permissions:`
  - `contents: read`

This preserves existing behavior (`actions/checkout` only needs repository read access) while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
