### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test
 on: [push]
+permissions:
+  contents: read
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/YnFOR/security/code-scanning/2](https://github.com/teremuhamblin/YnFOR/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/test.yml` so the workflow does not inherit potentially broad defaults.  
Best single fix without changing functionality: set root-level permissions to read-only for repository contents.

- **File to change:** `.github/workflows/test.yml`
- **Where:** directly under `on:` (before `jobs:`), add:
  - `permissions:`
  - `  contents: read`

This applies to all jobs in the workflow and is sufficient for this workflow’s current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
