### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [development, main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/YnFOR/security/code-scanning/3](https://github.com/teremuhamblin/YnFOR/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so the token is least-privileged.

Best fix here (without changing functionality): define workflow-level permissions with only `contents: read`, since the job only needs to read repository contents for `actions/checkout`. This applies to all jobs unless overridden and directly resolves CodeQL’s complaint.

Change needed in:
- **File:** `.github/workflows/lint.yml`
- **Region:** after the `on:` trigger block and before `jobs:`
- **Edit:** insert:
  ```yml
  permissions:
    contents: read
  ```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
